### PR TITLE
Add a fix for nth element bigger than 9

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const getValidationRegex = () => {
             "|"+
               "(?P<contained>contains\\((?P<cattr>@?%(attribute)s,\\s*[\"\\'](?P<cvalue>%(value)s)[\"\\']\\))"+// `[contains(@id, "bleh")]` supported and `[contains(text(), "some")]` is not
             ")\\])?"+
-            "(\\[\\s*(?P<nth>\\d|last\\(\\s*\\))\\s*\\])?"+
+            "(\\[\\s*(?P<nth>\\d+|last\\(\\s*\\))\\s*\\])?"+
           ")"+
         ")";
 

--- a/test.js
+++ b/test.js
@@ -23,6 +23,14 @@ test('conversion', function(assert) {
   expected = 'HTML > BODY > DIV#menu > NAV > UL:nth-of-type(5)';
   assert.equal(actual, expected);
 
+  actual = xPathToCss('/HTML/BODY/DIV[@id=\'menu\']/NAV/UL[10]');
+  expected = 'HTML > BODY > DIV#menu > NAV > UL:nth-of-type(10)';
+  assert.equal(actual, expected);
+
+  actual = xPathToCss('/HTML/BODY/DIV[@id=\'menu\']/NAV/UL[123]');
+  expected = 'HTML > BODY > DIV#menu > NAV > UL:nth-of-type(123)';
+  assert.equal(actual, expected);
+
   actual = xPathToCss('//div[@id="foo"][2]/span[@class="bar"]//a[contains(@class, "baz")]//img[1]');
   expected = 'div#foo:nth-of-type(2) > span.bar a[class*="baz"] img:first-of-type';
   assert.equal(actual, expected);


### PR DESCRIPTION
When providing an xpath that references and nth element 10 or higher the CSS that is generated is incorrect.

Updated the regex to look for multiple digits. 
Updated the test cases to show the bug was fixed.